### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
 
   def index
-    @items = Item.all
+    @items = Item.all.order("created_at DESC")
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,6 +3,7 @@ class ItemsController < ApplicationController
 
   def index
     @items = Item.all.order("created_at DESC")
+
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,9 +128,10 @@
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
+<% @items.each do |item| %> 
       <li class='list'>
         <%= link_to "#" do %>
-         <% @items.each do |item| %> 
+         
         <div class='item-img-content'>
         
             <%= image_tag item.image, class: "item-img" %>
@@ -155,8 +156,9 @@
             </div>
           </div>
           <% end%>
-        <% end %>
+     
       </li>
+         <% end %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,9 +126,7 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-<% @items.each do |item| %> 
+   <% @items.each do |item| %> 
       <li class='list'>
         <%= link_to "#" do %>
          
@@ -156,13 +154,10 @@
             </div>
           </div>
           <% end%>
-     
       </li>
-         <% end %>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+    <% end %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+    <% if  @items.empty? %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -180,8 +175,8 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+     <% end %>
+     
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -146,7 +146,7 @@
               <%= item.name %>
             </h3>
             <div class='item-price'>
-              <span><%= item.item_price %>円<br><%= '配送料負担' %></span>
+              <span><%= item.item_price %>円<br><%= item.cost.name %></span>
               <div class='star-btn'>
                 <%= image_tag "star.png", class:"star-icon" %>
                 <span class='star-count'>0</span>
@@ -176,7 +176,7 @@
         <% end %>
       </li>
      <% end %>
-     
+
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,30 +127,34 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+
       <li class='list'>
         <%= link_to "#" do %>
+         <% @items.each do |item| %> 
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+        
+            <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
+            <%# 商品が売れていればsold outを表示しましょう %>
+            <%# <div class='sold-out'> %>
+              <%# <span>Sold Out!!</span> %>
+            <%# </div> %>
+            <%# //商品が売れていればsold outを表示しましょう %>
+  
           </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              <%= item.name %>
+            </h3>
+            <div class='item-price'>
+              <span><%= item.item_price %>円<br><%= '配送料負担' %></span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
+          <% end%>
         <% end %>
       </li>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>


### PR DESCRIPTION
# What
商品一覧機能の実装

# Why
登録した商品を一覧表示するため
※「売却済みの商品は、画像上に『sold out』の文字が表示されるようになっていること」という機能に関しては、商品購入機能実装後に実装する予定ですので、一旦コメントアウトしています。


出品した商品の一覧表示
「画像/価格/商品名」の3つの情報について表示
https://i.gyazo.com/dc62e7df43ad36f50bf67efcb2aa1b70.png

上から、出品された日時が新しい順に表示
https://i.gyazo.com/512560f55ffb1bbd0f3c2253723533ff.gif

ログアウト状態のユーザーでも、商品一覧表示ページを見ることができる
https://i.gyazo.com/9c4e238e78c47bad0d3229cfe5dadae2.gif

商品のデータがない場合に、ダミー商品が表示されている
https://gyazo.com/6bf1ef936cd125bd1327e6a9025ff718