### PR TITLE
商品詳細表示機能の実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,8 +2,10 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   private
-  def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :family_name, :first_name, :family_name_kana, :first_name_kana, :birth_day])
-  end
 
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up,
+                                      keys: [:nickname, :family_name, :first_name, :family_name_kana, :first_name_kana,
+                                             :birth_day])
+  end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,8 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
 
   def index
-    @items = Item.all.order("created_at DESC")
-
+    @items = Item.all.order('created_at DESC')
   end
 
   def new
@@ -13,10 +12,10 @@ class ItemsController < ApplicationController
   def create
     @item = Item.new(item_params)
     if @item.save
-      redirect_to root_path     
-   else
-     render :new      
-   end
+      redirect_to root_path
+    else
+      render :new
+    end
   end
 
   def show
@@ -26,7 +25,7 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:name, :description, :category_id, :status_id, :cost_id, :area_id, :days_id, :item_price, :image).merge(user_id: current_user.id)
+    params.require(:item).permit(:name, :description, :category_id, :status_id, :cost_id, :area_id, :days_id, :item_price,
+                                 :image).merge(user_id: current_user.id)
   end
-
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: [:index]
+  before_action :authenticate_user!, except: [:index, :show]
 
   def index
     @items = Item.all.order("created_at DESC")
@@ -19,6 +19,9 @@ class ItemsController < ApplicationController
    end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
 
   private
 

--- a/app/models/area.rb
+++ b/app/models/area.rb
@@ -1,24 +1,23 @@
 class Area < ActiveHash::Base
   self.data = [
-    {id: 1, name: '--'},{id: 2, name: '北海道'}, {id: 3, name: '青森県'}, {id: 4, name: '岩手県'},
-    {id: 5, name: '宮城県'}, {id: 6, name: '秋田県'}, {id: 7, name: '山形県'},
-    {id: 8, name: '福島県'}, {id: 9, name: '茨城県'}, {id: 10, name: '栃木県'},
-    {id: 11, name: '群馬県'}, {id: 12, name: '埼玉県'}, {id: 13, name: '千葉県'},
-    {id: 14, name: '東京都'}, {id: 15, name: '神奈川県'}, {id: 16, name: '新潟県'},
-    {id: 17, name: '富山県'}, {id: 18, name: '石川県'}, {id: 19, name: '福井県'},
-    {id: 20, name: '山梨県'}, {id: 21, name: '長野県'}, {id: 22, name: '岐阜県'},
-    {id: 23, name: '静岡県'}, {id: 24, name: '愛知県'}, {id: 25, name: '三重県'},
-    {id: 26, name: '滋賀県'}, {id: 27, name: '京都府'}, {id: 28, name: '大阪府'},
-    {id: 29, name: '兵庫県'}, {id: 30, name: '奈良県'}, {id: 31, name: '和歌山県'},
-    {id: 32, name: '鳥取県'}, {id: 33, name: '島根県'}, {id: 34, name: '岡山県'},
-    {id: 35, name: '広島県'}, {id: 36, name: '山口県'}, {id: 37, name: '徳島県'},
-    {id: 38, name: '香川県'}, {id: 39, name: '愛媛県'}, {id: 40, name: '高知県'},
-    {id: 41, name: '福岡県'}, {id: 42, name: '佐賀県'}, {id: 43, name: '長崎県'},
-    {id: 44, name: '熊本県'}, {id: 45, name: '大分県'}, {id: 46, name: '宮崎県'},
-    {id: 47, name: '鹿児島県'}, {id: 48, name: '沖縄県'}
-]
+    { id: 1, name: '--' }, { id: 2, name: '北海道' }, { id: 3, name: '青森県' }, { id: 4, name: '岩手県' },
+    { id: 5, name: '宮城県' }, { id: 6, name: '秋田県' }, { id: 7, name: '山形県' },
+    { id: 8, name: '福島県' }, { id: 9, name: '茨城県' }, { id: 10, name: '栃木県' },
+    { id: 11, name: '群馬県' }, { id: 12, name: '埼玉県' }, { id: 13, name: '千葉県' },
+    { id: 14, name: '東京都' }, { id: 15, name: '神奈川県' }, { id: 16, name: '新潟県' },
+    { id: 17, name: '富山県' }, { id: 18, name: '石川県' }, { id: 19, name: '福井県' },
+    { id: 20, name: '山梨県' }, { id: 21, name: '長野県' }, { id: 22, name: '岐阜県' },
+    { id: 23, name: '静岡県' }, { id: 24, name: '愛知県' }, { id: 25, name: '三重県' },
+    { id: 26, name: '滋賀県' }, { id: 27, name: '京都府' }, { id: 28, name: '大阪府' },
+    { id: 29, name: '兵庫県' }, { id: 30, name: '奈良県' }, { id: 31, name: '和歌山県' },
+    { id: 32, name: '鳥取県' }, { id: 33, name: '島根県' }, { id: 34, name: '岡山県' },
+    { id: 35, name: '広島県' }, { id: 36, name: '山口県' }, { id: 37, name: '徳島県' },
+    { id: 38, name: '香川県' }, { id: 39, name: '愛媛県' }, { id: 40, name: '高知県' },
+    { id: 41, name: '福岡県' }, { id: 42, name: '佐賀県' }, { id: 43, name: '長崎県' },
+    { id: 44, name: '熊本県' }, { id: 45, name: '大分県' }, { id: 46, name: '宮崎県' },
+    { id: 47, name: '鹿児島県' }, { id: 48, name: '沖縄県' }
+  ]
 
   include ActiveHash::Associations
   has_many :items
-
-  end
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -15,5 +15,4 @@ class Category < ActiveHash::Base
 
   include ActiveHash::Associations
   has_many :items
-
-  end
+end

--- a/app/models/cost.rb
+++ b/app/models/cost.rb
@@ -2,10 +2,9 @@ class Cost < ActiveHash::Base
   self.data = [
     { id: 1,  name: '--' },
     { id: 2,  name: '着払い(購入者負担)' },
-    { id: 3,  name: '送料込み(出品者負担)' },
+    { id: 3,  name: '送料込み(出品者負担)' }
   ]
 
   include ActiveHash::Associations
   has_many :items
-
-  end
+end

--- a/app/models/days.rb
+++ b/app/models/days.rb
@@ -3,11 +3,10 @@ class Days < ActiveHash::Base
     { id: 1,  name: '--' },
     { id: 2,  name: '1〜2日で発送' },
     { id: 3,  name: '2〜3日で発送' },
-    { id: 4,  name: '4〜7日で発送' },
+    { id: 4,  name: '4〜7日で発送' }
 
   ]
 
   include ActiveHash::Associations
   has_many :items
-
-  end
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -8,20 +8,19 @@ class Item < ApplicationRecord
   belongs_to :area
   belongs_to :days
 
-
-  with_options presence: true do 
+  with_options presence: true do
     validates :name
     validates :description
     validates :user
     validates :image
   end
 
-  with_options numericality: { only_integer: true, other_than: 1} do
+  with_options numericality: { only_integer: true, other_than: 1 } do
     validates :category_id
     validates :cost_id
     validates :status_id
     validates :area_id
     validates :days_id
   end
-    validates :item_price,  numericality: { only_integer: true, greater_than:300, less_than:9999999}
+  validates :item_price, numericality: { only_integer: true, greater_than: 300, less_than: 9_999_999 }
 end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -6,10 +6,9 @@ class Status < ActiveHash::Base
     { id: 4,  name: '目立った傷や汚れなし' },
     { id: 5,  name: 'やや傷や汚れあり' },
     { id: 6,  name: '傷や汚れあり' },
-    { id: 7,  name: '全体的に状態が悪い' },
+    { id: 7,  name: '全体的に状態が悪い' }
   ]
 
   include ActiveHash::Associations
   has_many :items
-
-  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,8 +15,8 @@ class User < ApplicationRecord
       validates :first_name_kana
       validates :family_name_kana
     end
-    PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?[\d])[a-z\d]+\z/i.freeze
-    validates_format_of :password, with: PASSWORD_REGEX, message: 'には英字と数字の両方を含めて設定してください' 
+    PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i.freeze
+    validates_format_of :password, with: PASSWORD_REGEX, message: 'には英字と数字の両方を含めて設定してください'
     validates :birth_day
   end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,8 +127,8 @@
     <ul class='item-lists'>
 
    <% @items.each do |item| %> 
-      <li class='list'>
-        <%= link_to "#" do %>
+    <li class='list'>
+      <%= link_to item_path(item.id),method: :get  do %>
          
         <div class='item-img-content'>
         
@@ -153,9 +153,9 @@
               </div>
             </div>
           </div>
-          <% end%>
-      </li>
-    <% end %>
+       <% end%>
+    </li>
+   <% end %>
 
     <% if  @items.empty? %>
       <li class='list'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -21,7 +21,6 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
     <% if user_signed_in? && current_user.id == @item.user.id %>
 
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
@@ -33,8 +32,6 @@
     <%# //商品が売れていない場合はこちらを表示しましょう %>
     <% end %>
 
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= @item.description %></span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -22,7 +22,7 @@
     </div>
 
     <% if user_signed_in? %>
-     <% if user_signed_in? && current_user.id == @item.user.id %>
+     <% if current_user.id == @item.user.id %>
       <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
       <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,26 +4,25 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
-        <span>Sold Out!!</span>
-      </div>
+      <%# <div class="sold-out"> %>
+        <%# <span>Sold Out!!</span> %>
+      <%# </div> %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
-      <span class="item-price">
-        ¥ 999,999,999
-      </span>
+      <span class="item-price">¥<%= @item.item_price %></span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.cost.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% if user_signed_in? && current_user.id == @item.user.id %>
 
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
@@ -32,38 +31,39 @@
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% end %>
 
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.cost.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.days.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,6 +27,7 @@
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
 
+    <% else user_signed_in? && current_user.id != @item.user.id %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -21,17 +21,17 @@
       </span>
     </div>
 
-    <% if user_signed_in? && current_user.id == @item.user.id %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
-    <% else user_signed_in? && current_user.id != @item.user.id %>
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-    <% end %>
+    <% if user_signed_in? %>
+     <% if user_signed_in? && current_user.id == @item.user.id %>
+      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+      <p class="or-text">or</p>
+      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+      <% else  %>
+      <%# 商品が売れていない場合はこちらを表示しましょう %>
+      <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+      <%# //商品が売れていない場合はこちらを表示しましょう %>
+      <% end %>
+   <% end %>
 
 
     <div class="item-explain-box">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   get 'items/index'
   root to: "items#index"
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show]
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,19 +1,19 @@
 FactoryBot.define do
   factory :item do
-    name            {Faker::Name.initials}
-    description     {Faker::Lorem.sentence}
+    name            { Faker::Name.initials }
+    description     { Faker::Lorem.sentence }
 
-    category_id     {Faker::Number.between(from: 2, to: 11)}
-    status_id       {Faker::Number.between(from: 2, to: 7)}
-    cost_id         {Faker::Number.between(from: 2, to: 3)}
-    area_id         {Faker::Number.between(from: 2, to: 47)}
-    days_id         {Faker::Number.between(from: 2, to: 4)}
-    item_price      {Faker::Number.between(from: 300, to: 9999999)}
-    association :user 
+    category_id     { Faker::Number.between(from: 2, to: 11) }
+    status_id       { Faker::Number.between(from: 2, to: 7) }
+    cost_id         { Faker::Number.between(from: 2, to: 3) }
+    area_id         { Faker::Number.between(from: 2, to: 47) }
+    days_id         { Faker::Number.between(from: 2, to: 4) }
+    item_price      { Faker::Number.between(from: 300, to: 9_999_999) }
+    association :user
 
     after(:build) do |item|
-      item.image.attach(io: File.open('spec/fixtures/furima-intro06.png'), filename: 'furima-intro06.png', content_type: 'image/png')
+      item.image.attach(io: File.open('spec/fixtures/furima-intro06.png'), filename: 'furima-intro06.png',
+                        content_type: 'image/png')
     end
-    
   end
 end

--- a/spec/factories/models.rb
+++ b/spec/factories/models.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :model do
-    
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,13 +1,13 @@
 FactoryBot.define do
   factory :user do
-    nickname              {Faker::Name.initials}
-    email                 {Faker::Internet.free_email}
-    password              {Faker::Internet.password(min_length: 6, mix_case: true)}
-    password_confirmation {password}
-    family_name           {Gimei.last.kanji}
-    first_name            {Gimei.first.kanji}
-    family_name_kana      {Gimei.last.katakana}
-    first_name_kana       {Gimei.first.katakana}
-    birth_day             {Faker::Date.birthday}
+    nickname              { Faker::Name.initials }
+    email                 { Faker::Internet.free_email }
+    password              { Faker::Internet.password(min_length: 6, mix_case: true) }
+    password_confirmation { password }
+    family_name           { Gimei.last.kanji }
+    first_name            { Gimei.first.kanji }
+    family_name_kana      { Gimei.last.katakana }
+    first_name_kana       { Gimei.first.katakana }
+    birth_day             { Faker::Date.birthday }
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -4,98 +4,98 @@ RSpec.describe Item, type: :model do
     @item = FactoryBot.build(:item)
   end
 
-  describe '商品出品機能' do 
-   context '商品出品できるとき' do
-    it 'name、description、category_id、status_id、cost_id、area_id、days_id、item_priceが存在すれば出品できる' do 
-      expect(@item).to be_valid
+  describe '商品出品機能' do
+    context '商品出品できるとき' do
+      it 'name、description、category_id、status_id、cost_id、area_id、days_id、item_priceが存在すれば出品できる' do
+        expect(@item).to be_valid
+      end
     end
-   end
-   context'商品出品できないとき' do
-    it 'nameが空では出品できない' do 
-      @item.name = ''
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Name can't be blank")
+    context '商品出品できないとき' do
+      it 'nameが空では出品できない' do
+        @item.name = ''
+        @item.valid?
+        expect(@item.errors.full_messages).to include("Name can't be blank")
+      end
+      it 'descriptionが空では出品できない' do
+        @item.description = ''
+        @item.valid?
+        expect(@item.errors.full_messages).to include("Description can't be blank")
+      end
+      it 'imageが空では出品できない' do
+        @item.image = nil
+        @item.valid?
+        expect(@item.errors.full_messages).to include("Image can't be blank")
+      end
+      it 'category_idが空では出品できない' do
+        @item.category_id = ''
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Category is not a number')
+      end
+      it 'category_idが1では出品できない' do
+        @item.category_id = 1
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Category must be other than 1')
+      end
+      it 'status_idが空では出品できない' do
+        @item.status_id = ''
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Status is not a number')
+      end
+      it 'status_idが1では出品できない' do
+        @item.status_id = 1
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Status must be other than 1')
+      end
+      it 'cost_idが空では出品できない' do
+        @item.cost_id = ''
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Cost is not a number')
+      end
+      it 'cost_idが1では出品できない' do
+        @item.cost_id = 1
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Cost must be other than 1')
+      end
+      it 'area_idが空では出品できない' do
+        @item.area_id = ''
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Area is not a number')
+      end
+      it 'area_idが0では出品できない' do
+        @item.area_id = 1
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Area must be other than 1')
+      end
+      it 'days_idが空では出品できない' do
+        @item.days_id = ''
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Days is not a number')
+      end
+      it 'days_idが1では出品できない' do
+        @item.days_id = 1
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Days must be other than 1')
+      end
+      it 'item_priceが空では出品できない' do
+        @item.item_price = ''
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Item price is not a number')
+      end
+      it 'item_priceが300円以下では出品できない' do
+        @item.item_price = 200
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Item price must be greater than 300')
+      end
+      it 'item_priceが9999999円以上では出品できない' do
+        @item.item_price = 999_999_999_999
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Item price must be less than 9999999')
+      end
+      it 'item_priceは半角数字のみ保存可能' do
+        @item.item_price = 'あああ'
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Item price is not a number')
+      end
     end
-    it 'descriptionが空では出品できない' do
-      @item.description = ''
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Description can't be blank")
-    end
-    it 'imageが空では出品できない' do 
-      @item.image = nil
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Image can't be blank")
-    end
-    it 'category_idが空では出品できない' do
-      @item.category_id = ''
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Category is not a number")
-    end
-    it 'category_idが1では出品できない' do
-      @item.category_id = 1
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Category must be other than 1")
-    end
-    it 'status_idが空では出品できない' do
-      @item.status_id = ''
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Status is not a number")
-    end
-    it 'status_idが1では出品できない' do
-      @item.status_id = 1
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Status must be other than 1")
-    end
-    it 'cost_idが空では出品できない' do
-      @item.cost_id = ''
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Cost is not a number")
-    end
-    it 'cost_idが1では出品できない' do
-      @item.cost_id = 1
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Cost must be other than 1")
-    end
-    it 'area_idが空では出品できない' do
-      @item.area_id = ''
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Area is not a number")
-    end
-    it 'area_idが0では出品できない' do
-      @item.area_id = 1
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Area must be other than 1")
-    end
-    it 'days_idが空では出品できない' do
-      @item.days_id = ''
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Days is not a number")
-    end
-    it 'days_idが1では出品できない' do
-      @item.days_id = 1
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Days must be other than 1")
-    end
-    it 'item_priceが空では出品できない' do
-      @item.item_price = ''
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Item price is not a number")
-    end
-    it 'item_priceが300円以下では出品できない' do
-      @item.item_price = 200
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Item price must be greater than 300")
-    end
-    it 'item_priceが9999999円以上では出品できない' do
-      @item.item_price = 999999999999
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Item price must be less than 9999999")
-    end
-    it 'item_priceは半角数字のみ保存可能' do
-      @item.item_price = 'あああ'
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Item price is not a number")
-    end
-   end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,134 +5,128 @@ RSpec.describe User, type: :model do
   end
 
   describe 'ユーザー新規登録' do
-   context '新規登録できるとき' do
-    it 'nicknameとemail、passwordとpassword_confirmation、family_nameとfirst_name、family_name_kanaとfirst_name_kanaが存在すれば登録できる' do
-      expect(@user).to be_valid
+    context '新規登録できるとき' do
+      it 'nicknameとemail、passwordとpassword_confirmation、family_nameとfirst_name、family_name_kanaとfirst_name_kanaが存在すれば登録できる' do
+        expect(@user).to be_valid
+      end
     end
-   end
-   context '新規登録できないとき' do
-    it 'nicknameが空では登録できない' do
-      @user.nickname = ''
-      @user.valid?
-      expect(@user.errors.full_messages).to include ("Nickname can't be blank")
-    end
-    it 'emailが空では登録できない' do
-      @user.email = ''
-      @user.valid?
-      expect(@user.errors.full_messages).to include ("Email can't be blank")
-    end
-    it '重複したemailが存在する場合登録できない' do 
-      @user.save
-      another_user = FactoryBot.build(:user)
-      another_user.email = @user.email
-      another_user.valid?
-      expect(another_user.errors.full_messages).to include('Email has already been taken')    
-    end
-    it 'emailは@がなければ登録できない' do
-      @user.email = 'aaaaa'
-      @user.valid?
-      expect(@user.errors.full_messages).to include ("Email is invalid")
-    end
-    it 'passeordが空では登録できない' do 
-      @user.password = ''
-      @user.valid?
-      expect(@user.errors.full_messages).to include("Password can't be blank")    
-    end
-    it 'password:半角英数混合(半角英語のみ)' do 
-      @user.password = 'aaaaaaa'
-      @user.password_confirmation = 'aaaaaaa'
-      @user.valid?
-      expect(@user.errors.full_messages).to include("Password には英字と数字の両方を含めて設定してください")
-    end    
-    it 'password:半角英数混合(数字のみ)' do 
-      @user.password = '111111'
-      @user.password_confirmation = '111111'
-      @user.valid?
-      expect(@user.errors.full_messages).to include("Password には英字と数字の両方を含めて設定してください")
-    end    
-    it 'passwordは半角英数混合でなければ登録できない' do 
-      @user.password = 'aaaaaa'
-      @user.password_confirmation = 'aaaaaa'
-      @user.valid?
-      expect(@user.errors.full_messages).to include("Password には英字と数字の両方を含めて設定してください")
-    end    
-    it 'passwordが存在してもpassword_confirmationが空では登録できない' do
-      @user.password_confirmation = ''
-      @user.valid?
-      expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")    
-    end
-    it 'passwordとpassword_confirmationが違えば登録できない' do
-      @user.password_confirmation = 'aaaaa1'
-      @user.valid?
-      expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")    
-    end
-    it 'passwordが5文字以下では登録できない' do
-      @user.password = '00000'
-      @user.password_confirmation = '00000'
-      @user.valid?
-      expect(@user.errors.full_messages).to include('Password is too short (minimum is 6 characters)')
-    end
-    it 'family_nameが空では登録できない' do
-      @user.family_name = ''
-      @user.valid?
-      expect(@user.errors.full_messages).to include("Family name can't be blank")    
-    end
-    it 'first_nameが空では登録できない' do 
-      @user.first_name = ''
-      @user.valid?
-      expect(@user.errors.full_messages).to include("First name can't be blank")    
-    end
-    it 'family_name_kanaが空では登録できない' do 
-      @user.family_name_kana = ''
-      @user.valid?
-      expect(@user.errors.full_messages).to include("Family name kana can't be blank")    
-    end
-    it 'first_name_kanaが空では登録できない' do 
-      @user.first_name_kana = ''
-      @user.valid?
-      expect(@user.errors.full_messages).to include("First name kana can't be blank")    
-    end
-    it 'birth_dayが空では登録できない' do
-      @user.birth_day = ''
-      @user.valid?
-      expect(@user.errors.full_messages).to include("Birth day can't be blank")    
-    end
-    it 'family_nameは全角のみ' do
-      @user.family_name = 'aaa'
-      @user.valid?
-      expect(@user.errors.full_messages).to include("Family name 全角文字を使用してください")    
-    end
-    it 'first_nameは全角のみ' do
-      @user.first_name = 'aaa'
-      @user.valid?
-      expect(@user.errors.full_messages).to include("First name 全角文字を使用してください") 
-    end   
-    it 'family_name_kanaはカタカナのみ' do
-      @user.family_name_kana = 'aaa'
-      @user.valid?
-      expect(@user.errors.full_messages).to include("Family name kana カタカナを使用してください")   
-    end
-    it 'family_name_kanaは全角（カタカナ以外）では登録できない' do
-      @user.family_name_kana = 'あああ'
-      @user.valid?
-      expect(@user.errors.full_messages).to include("Family name kana カタカナを使用してください")   
-    end
-    it 'first_name_kanaはカタカナのみ' do
-      @user.first_name_kana = 'aaa'
-      @user.valid?
-      expect(@user.errors.full_messages).to include("First name kana カタカナを使用してください")   
-    end    
-    it 'first_name_kanaは全角（カタカナ以外）では登録できない' do
-      @user.first_name_kana = 'あああ'
-      @user.valid?
-      expect(@user.errors.full_messages).to include("First name kana カタカナを使用してください")   
+    context '新規登録できないとき' do
+      it 'nicknameが空では登録できない' do
+        @user.nickname = ''
+        @user.valid?
+        expect(@user.errors.full_messages).to include("Nickname can't be blank")
+      end
+      it 'emailが空では登録できない' do
+        @user.email = ''
+        @user.valid?
+        expect(@user.errors.full_messages).to include("Email can't be blank")
+      end
+      it '重複したemailが存在する場合登録できない' do
+        @user.save
+        another_user = FactoryBot.build(:user)
+        another_user.email = @user.email
+        another_user.valid?
+        expect(another_user.errors.full_messages).to include('Email has already been taken')
+      end
+      it 'emailは@がなければ登録できない' do
+        @user.email = 'aaaaa'
+        @user.valid?
+        expect(@user.errors.full_messages).to include('Email is invalid')
+      end
+      it 'passeordが空では登録できない' do
+        @user.password = ''
+        @user.valid?
+        expect(@user.errors.full_messages).to include("Password can't be blank")
+      end
+      it 'password:半角英数混合(半角英語のみ)' do
+        @user.password = 'aaaaaaa'
+        @user.password_confirmation = 'aaaaaaa'
+        @user.valid?
+        expect(@user.errors.full_messages).to include('Password には英字と数字の両方を含めて設定してください')
+      end
+      it 'password:半角英数混合(数字のみ)' do
+        @user.password = '111111'
+        @user.password_confirmation = '111111'
+        @user.valid?
+        expect(@user.errors.full_messages).to include('Password には英字と数字の両方を含めて設定してください')
+      end
+      it 'passwordは半角英数混合でなければ登録できない' do
+        @user.password = 'aaaaaa'
+        @user.password_confirmation = 'aaaaaa'
+        @user.valid?
+        expect(@user.errors.full_messages).to include('Password には英字と数字の両方を含めて設定してください')
+      end
+      it 'passwordが存在してもpassword_confirmationが空では登録できない' do
+        @user.password_confirmation = ''
+        @user.valid?
+        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
+      end
+      it 'passwordとpassword_confirmationが違えば登録できない' do
+        @user.password_confirmation = 'aaaaa1'
+        @user.valid?
+        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
+      end
+      it 'passwordが5文字以下では登録できない' do
+        @user.password = '00000'
+        @user.password_confirmation = '00000'
+        @user.valid?
+        expect(@user.errors.full_messages).to include('Password is too short (minimum is 6 characters)')
+      end
+      it 'family_nameが空では登録できない' do
+        @user.family_name = ''
+        @user.valid?
+        expect(@user.errors.full_messages).to include("Family name can't be blank")
+      end
+      it 'first_nameが空では登録できない' do
+        @user.first_name = ''
+        @user.valid?
+        expect(@user.errors.full_messages).to include("First name can't be blank")
+      end
+      it 'family_name_kanaが空では登録できない' do
+        @user.family_name_kana = ''
+        @user.valid?
+        expect(@user.errors.full_messages).to include("Family name kana can't be blank")
+      end
+      it 'first_name_kanaが空では登録できない' do
+        @user.first_name_kana = ''
+        @user.valid?
+        expect(@user.errors.full_messages).to include("First name kana can't be blank")
+      end
+      it 'birth_dayが空では登録できない' do
+        @user.birth_day = ''
+        @user.valid?
+        expect(@user.errors.full_messages).to include("Birth day can't be blank")
+      end
+      it 'family_nameは全角のみ' do
+        @user.family_name = 'aaa'
+        @user.valid?
+        expect(@user.errors.full_messages).to include('Family name 全角文字を使用してください')
+      end
+      it 'first_nameは全角のみ' do
+        @user.first_name = 'aaa'
+        @user.valid?
+        expect(@user.errors.full_messages).to include('First name 全角文字を使用してください')
+      end
+      it 'family_name_kanaはカタカナのみ' do
+        @user.family_name_kana = 'aaa'
+        @user.valid?
+        expect(@user.errors.full_messages).to include('Family name kana カタカナを使用してください')
+      end
+      it 'family_name_kanaは全角（カタカナ以外）では登録できない' do
+        @user.family_name_kana = 'あああ'
+        @user.valid?
+        expect(@user.errors.full_messages).to include('Family name kana カタカナを使用してください')
+      end
+      it 'first_name_kanaはカタカナのみ' do
+        @user.first_name_kana = 'aaa'
+        @user.valid?
+        expect(@user.errors.full_messages).to include('First name kana カタカナを使用してください')
+      end
+      it 'first_name_kanaは全角（カタカナ以外）では登録できない' do
+        @user.first_name_kana = 'あああ'
+        @user.valid?
+        expect(@user.errors.full_messages).to include('First name kana カタカナを使用してください')
+      end
     end
   end
- end
 end
-
-
-
-
-
-

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,53 +44,51 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
-  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
-  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  #   # This allows you to limit a spec run to individual examples or groups
+  #   # you care about by tagging them with `:focus` metadata. When nothing
+  #   # is tagged with `:focus`, all examples get run. RSpec also provides
+  #   # aliases for `it`, `describe`, and `context` that include `:focus`
+  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  #   config.filter_run_when_matching :focus
+  #
+  #   # Allows RSpec to persist some state between runs in order to support
+  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
+  #   # you configure your source control system to ignore this file.
+  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
+  #   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+  #   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
+  #   config.disable_monkey_patching!
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = "doc"
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :selenium, using: :chrome, screen_size: [1400, 1400]

--- a/test/channels/application_cable/connection_test.rb
+++ b/test/channels/application_cable/connection_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class ApplicationCable::ConnectionTest < ActionCable::Connection::TestCase
   # test "connects with cookies" do

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -1,9 +1,8 @@
 require 'test_helper'
 
 class ItemsControllerTest < ActionDispatch::IntegrationTest
-  test "should get index" do
+  test 'should get index' do
     get items_index_url
     assert_response :success
   end
-
 end


### PR DESCRIPTION
# What
商品詳細表示機能の実装

# Why
商品の詳細を表示するため
※「ログイン状態の出品者でも、売却済みの商品に対しては「編集・削除ボタン」が表示されないこと」
「売却済みの商品は、画像上に『sold out』の文字が表示されるようになっていること」
の２点は商品購入機能実装後に実装します。コメントアウトしてあったりします。


ログイン状態の出品者のみ、「編集・削除ボタン」が表示される
https://i.gyazo.com/d5eb52eac5cb62360418bd8ee773afb6.gif

ログイン状態の出品者以外のユーザーのみ、「購入画面に進むボタン」が表示される
https://i.gyazo.com/a747af663c48d9e5bccc705f0f76b4bf.gif

ログアウト状態のユーザーでも、商品詳細表示ページを閲覧できる
ログアウト状態のユーザーには、「編集・削除・購入画面に進むボタン」が表示されない
https://i.gyazo.com/ecd90c569c9ef39de6e0901d650eec67.gif

商品出品時に登録した情報が見られる
https://i.gyazo.com/b754e87d8f139e9b09f58cc00fc44189.gif
